### PR TITLE
update the default Name and Git reference when create Notebook with O…

### DIFF
--- a/bundle/manifests/openvino-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openvino-operator.clusterserviceversion.yaml
@@ -68,10 +68,10 @@ metadata:
           "apiVersion": "intel.com/v1alpha1",
           "kind": "Notebook",
           "metadata": {
-            "name": "v2024.1"
+            "name": "latest"
           },
           "spec": {
-            "git_ref": "2024.1",
+            "git_ref": "latest",
             "auto_update_image": false
           }
         }


### PR DESCRIPTION
When creating Notebook with OpenVINO Toolkit Operator, the default Name and Git reference are "v2024.1" and "2024.1", but the build failed using the parameters because of the http://mirror.centos.org/centos/8-stream/A.../Packages/ocl-icd-2.2.12-1.el8.x86_64.rpm package is NOT exist anymore.

Error:
```
Complete!
curl: (22) The requested URL returned error: 404 Not Found
error: skipping http://mirror.centos.org/centos/8-stream/A.../Packages/ocl-icd-2.2.12-1.el8.x86_64.rpm - transfer failed
Retrieving http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/ocl-icd-2.2.12-1.el8.x86_64.rpm
error: build error: building at STEP "RUN rpm -ivh https:/....21-4.el8.x86_64.rpm": while running runtime: exit status 1

```

So I suggest to change the default git reference from the "2024.1" to "latest", here is the testing result:

**Before the change - 2024.1**
![image](https://github.com/user-attachments/assets/796f885a-2a05-47d0-b0f6-ce0e3adc6010)

**After the change - latest**
![image](https://github.com/user-attachments/assets/e79fdece-471c-4932-8e54-a1f73b7cfd1d)





